### PR TITLE
Make nested `add` recursive calls bypass `_handleAdd`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -786,11 +786,12 @@ export abstract class NamespaceBase extends ReflectionObject {
     /**
      * Adds a nested object to this namespace.
      * @param object Nested object to add
+     * @param [deferOnAddRecursion] If `true`, skips recursive root setup in `onAdd`
      * @returns `this`
      * @throws {TypeError} If arguments are invalid
      * @throws {Error} If there is already a nested object with this name
      */
-    public add(object: ReflectionObject): Namespace;
+    public add(object: ReflectionObject, deferOnAddRecursion?: boolean): Namespace;
 
     /**
      * Removes a nested object from this namespace.
@@ -936,8 +937,9 @@ export abstract class ReflectionObject {
     /**
      * Called when this object is added to a parent.
      * @param parent Parent added to
+     * @param [deferRecursion] If `true`, skips recursive setup of the root
      */
-    public onAdd(parent: ReflectionObject): void;
+    public onAdd(parent: ReflectionObject, deferRecursion?: boolean): void;
 
     /**
      * Called when this object is removed from a parent.

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -211,11 +211,12 @@ Namespace.prototype.getEnum = function getEnum(name) {
 /**
  * Adds a nested object to this namespace.
  * @param {ReflectionObject} object Nested object to add
+ * @param {boolean} [deferOnAddRecursion] If `true`, skips recursive root setup in `onAdd`
  * @returns {Namespace} `this`
  * @throws {TypeError} If arguments are invalid
  * @throws {Error} If there is already a nested object with this name
  */
-Namespace.prototype.add = function add(object) {
+Namespace.prototype.add = function add(object, deferOnAddRecursion) {
 
     if (!(object instanceof Field && object.extend !== undefined || object instanceof Type  || object instanceof OneOf || object instanceof Enum || object instanceof Service || object instanceof Namespace))
         throw TypeError("object must be a valid nested object");
@@ -229,7 +230,7 @@ Namespace.prototype.add = function add(object) {
                 // replace plain namespace but keep existing nested elements and options
                 var nested = prev.nestedArray;
                 for (var i = 0; i < nested.length; ++i)
-                    object.add(nested[i]);
+                    object.add(nested[i], true);
                 this.remove(prev);
                 if (!this.nested)
                     this.nested = {};
@@ -249,7 +250,7 @@ Namespace.prototype.add = function add(object) {
         }
     }
 
-    object.onAdd(this);
+    object.onAdd(this, deferOnAddRecursion);
     return clearCache(this);
 };
 

--- a/src/object.js
+++ b/src/object.js
@@ -140,15 +140,16 @@ ReflectionObject.prototype.toJSON = /* istanbul ignore next */ function toJSON()
 /**
  * Called when this object is added to a parent.
  * @param {ReflectionObject} parent Parent added to
+ * @param {boolean} [deferRecursion] If `true`, skips recursive setup of the root
  * @returns {undefined}
  */
-ReflectionObject.prototype.onAdd = function onAdd(parent) {
+ReflectionObject.prototype.onAdd = function onAdd(parent, deferRecursion) {
     if (this.parent && this.parent !== parent)
         this.parent.remove(this);
     this.parent = parent;
     this.resolved = false;
     var root = parent.root;
-    if (root instanceof Root)
+    if (root instanceof Root && !deferRecursion)
         root._handleAdd(this);
 };
 


### PR DESCRIPTION
`_handleAdd` recursively visits the whole Namespace tree. Doing this once from the end of the outermost `add` call is sufficient. Doing it for each call to `add` in the same tree is redundant and expensive.

When `add` is initially called, from `addJSON` in our case, the new param is `undefined`. For all nested `add` calls, the new param is true which will result in onAdd skipping `_handleAdd`. `_handleAdd` will be called once at the very end.